### PR TITLE
[LYM] refactor: pathname에 따른 페이지 props로 내려주어 관심사 분리

### DIFF
--- a/src/components/sign/SignForm.tsx
+++ b/src/components/sign/SignForm.tsx
@@ -1,9 +1,8 @@
 import { signIn, signUp } from 'api/authApi';
 import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-function SignForm() {
-	const { pathname } = useLocation();
+function SignForm({ page }: { page: string }) {
 	const navigate = useNavigate();
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
@@ -37,7 +36,7 @@ function SignForm() {
 			password,
 		};
 
-		if (pathname === '/signup') {
+		if (page === 'signup') {
 			const { status } = await signUp(body);
 			if (status === 201) {
 				navigate('/signin');
@@ -51,7 +50,7 @@ function SignForm() {
 	};
 
 	const handleNavigation = () => {
-		if (pathname === '/signin') {
+		if (page === 'signin') {
 			navigate('/signup');
 		} else {
 			navigate('/signin');
@@ -80,7 +79,7 @@ function SignForm() {
 					required
 				/>
 			</div>
-			{pathname === '/signup' ? (
+			{page === 'signup' ? (
 				<>
 					<button type="submit" disabled={isDisabled} data-testid="signup-button">
 						회원가입

--- a/src/pages/Sign.tsx
+++ b/src/pages/Sign.tsx
@@ -1,8 +1,16 @@
 import SignForm from 'components/sign/SignForm';
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 function Sign() {
-	return <SignForm />;
+	const { pathname } = useLocation();
+	let page = 'signin';
+
+	if (pathname === '/signup') {
+		page = 'signup';
+	}
+
+	return <SignForm page={page} />;
 }
 
 export default Sign;


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 

## 💸 작업 내용

- SignForm.tsx 에서 pathname 구분하던 로직을 Sign.tsx 페이지로 옮겨 관심사 분리

