### PR TITLE
[ONR] feat: 라우터, 레이아웃,리다이렉트 세팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { RouterProvider } from 'react-router-dom';
+import rootRouter from './router';
 
 function App() {
-	return <div>App</div>;
+	return <RouterProvider router={rootRouter} />;
 }
 
 export default App;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+import useAuthContext from '../../context/AuthContext';
+
+function Header() {
+	const { token, clearToken } = useContext(useAuthContext);
+
+	const logout = () => {
+		clearToken();
+	};
+
+	return (
+		<header>
+			{token !== null && (
+				<div>
+					<h1>ToDo List</h1>
+					<button type="button" onClick={logout}>
+						로그아웃
+					</button>
+				</div>
+			)}
+		</header>
+	);
+}
+
+export default Header;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, ReactNode, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const useAuthContext = createContext<{
+	token: string | null;
+	saveToken: (token: string) => void;
+	clearToken: () => void;
+}>({ token: null, saveToken: () => {}, clearToken: () => {} });
+
+export default useAuthContext;
+
+export function AuthContextProvider({ children }: { children: ReactNode }) {
+	const navigate = useNavigate();
+	const token = localStorage.getItem('ACCESS_TOKEN');
+
+	const saveToken = useCallback(
+		(jwt: string) => {
+			localStorage.setItem('ACCESS_TOKEN', jwt);
+			navigate('/todo');
+		},
+		[navigate],
+	);
+
+	const clearToken = useCallback(() => {
+		localStorage.removeItem('ACCESS_TOKEN');
+		navigate('/signin');
+	}, [navigate]);
+
+	const memoizedValue = useMemo(() => ({ token, saveToken, clearToken }), [token, saveToken, clearToken]);
+
+	return <useAuthContext.Provider value={memoizedValue}>{children}</useAuthContext.Provider>;
+}

--- a/src/pages/Redirect.tsx
+++ b/src/pages/Redirect.tsx
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthContext } from '../context/AuthContext';
+
+export function UnAuthorized() {
+	const { token } = useContext(useAuthContext);
+	if (token !== null) {
+		return <Navigate to="/todo" />;
+	}
+	return <Outlet />;
+}
+
+export function Authorized() {
+	const { token } = useContext(useAuthContext);
+	if (token === null) {
+		return <Navigate to="/signin" />;
+	}
+	return <Outlet />;
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { createBrowserRouter, createRoutesFromElements, Navigate, Route, Outlet } from 'react-router-dom';
+// import Sign from '../pages/Sign';
+import { AuthContextProvider } from 'context/AuthContext';
+// import Todo from '../pages/Todo';
+import Error from '../pages/Error';
+import { Authorized, UnAuthorized } from '../pages/Redirect';
+import Header from '../components/layout/Header';
+
+function Layout() {
+	return (
+		<AuthContextProvider>
+			<Header />
+			<Outlet />
+		</AuthContextProvider>
+	);
+}
+
+const router = (
+	<Route element={<Layout />}>
+		<Route element={<UnAuthorized />}>
+			{/* <Route path="/signin" element={<Sign />} />
+			<Route path="/signup" element={<Sign />} /> */}
+		</Route>
+		<Route element={<Authorized />}>
+			<Route path="/" element={<Navigate to="/todo" replace />} />
+			{/* <Route path="/todo" element={<Todo />} /> */}
+		</Route>
+		<Route path="*" element={<Error />} />
+	</Route>
+);
+
+const rootRouter = createBrowserRouter(createRoutesFromElements(router));
+
+export default rootRouter;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { createBrowserRouter, createRoutesFromElements, Navigate, Route, Outlet } from 'react-router-dom';
-// import Sign from '../pages/Sign';
-import { AuthContextProvider } from 'context/AuthContext';
-// import Todo from '../pages/Todo';
+import Sign from '../pages/Sign';
+import { AuthContextProvider } from '../context/AuthContext';
+import Todo from '../pages/Todo';
 import Error from '../pages/Error';
 import { Authorized, UnAuthorized } from '../pages/Redirect';
 import Header from '../components/layout/Header';
@@ -19,12 +19,12 @@ function Layout() {
 const router = (
 	<Route element={<Layout />}>
 		<Route element={<UnAuthorized />}>
-			{/* <Route path="/signin" element={<Sign />} />
-			<Route path="/signup" element={<Sign />} /> */}
+			<Route path="/signin" element={<Sign />} />
+			<Route path="/signup" element={<Sign />} />
 		</Route>
 		<Route element={<Authorized />}>
 			<Route path="/" element={<Navigate to="/todo" replace />} />
-			{/* <Route path="/todo" element={<Todo />} /> */}
+			<Route path="/todo" element={<Todo />} />
 		</Route>
 		<Route path="*" element={<Error />} />
 	</Route>


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 알릴 사항 또는 확인 요청 작성
- Sign 페이지를 하나로 만들기로해서 라우터 경로는 "/signin", "/signup" 2개로 나누고 보여주는 페이지는 둘 다 Sign으로 지정
- Layout 파일을 따로 제작하지 않고 router 페이지 안에서 컴포넌트를 선언했는데 파일을 따로 제작해야되는지 알려주시면 수정하겠습니다
- 윤정님의 AuthContextProvider를 똑같이 구현했습니다
#

## 💸 작업 내용

- 작업 개요(이슈 번호)
- 작업내용 1 : 라우터, 리다이렉트 세팅
- 작업내용 2 : 레이아웃 세팅
