### PR TITLE
[LYM] feat: 페이지 전환 시 입력했던 input value 초기화 되도록 변경

### DIFF
--- a/src/components/sign/SignForm.tsx
+++ b/src/components/sign/SignForm.tsx
@@ -15,6 +15,11 @@ function SignForm({ page }: { page: string }) {
 		setIsDisabled(!(isComplete.id && isComplete.password));
 	}, [isComplete]);
 
+	useEffect(() => {
+		setEmail('');
+		setPassword('');
+	}, [page]);
+
 	const emailCheck = (e: ChangeEvent<HTMLInputElement>) => {
 		setIsComplete(
 			e.target.value.includes('@')
@@ -42,6 +47,7 @@ function SignForm({ page }: { page: string }) {
 			try {
 				const { status } = await signUp(body);
 				if (status === 201) {
+					alert('회원가입이 완료되었습니다');
 					navigate('/signin');
 				} else {
 					throw new Error('회원가입 중 오류가 발생했습니다');
@@ -86,6 +92,7 @@ function SignForm({ page }: { page: string }) {
 				<span>아이디</span>
 				<input
 					onChange={emailCheck}
+					value={email}
 					type="email"
 					data-testid="email-input"
 					placeholder="이메일을 입력해주세요"
@@ -96,6 +103,7 @@ function SignForm({ page }: { page: string }) {
 				<span>비밀번호</span>
 				<input
 					onChange={passwordCheck}
+					value={password}
 					type="password"
 					data-testid="password-input"
 					placeholder="8자 이상의 비밀번호를 입력해주세요"


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 로그인, 회원가입 페이지의 input value가 페이지가 변경되어도 초기화 되지 않고 공유하고 있는 문제가 있었습니다.

## 💸 작업 내용

- useEffect 함수 이용하여 페이지 변경시 email, password state가 초기화 되도록 변경 하였습니다.
